### PR TITLE
change timestamps on copy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,5 @@
 # Changes for copy-on-write
 
+## 2023-03-06
+
+Update timestamps when copying

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,4 +2,4 @@
 
 ## 2023-03-06
 
-Update timestamps when copying
+Set created/modified timestamp to now on copy

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README - copy on write
 
-Docker image to maintain a duplicated directory structure. Works based on filesystem events. Copies a file/directory from a tracked source directory when it is created or moved to the source directory. Works based on regex substitution. See [replacements](localdev/replacements.sed) for an example mapping.
+Docker image to maintain a duplicated directory structure. Works based on filesystem events. Copies a file/directory from a tracked source directory when it is created or moved to the source directory. Timestamps of the original file will not be preserved. Works based on regex substitution. See [replacements](localdev/replacements.sed) for an example mapping.
 
 On startup existing files/directories in SOURCE_ROOT are mapped and copied to target if mapped.
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -28,7 +28,7 @@ function copyIfMapped {
   replacedPath=$(echo "$originalPath" | sed -r -f "${SCRIPT_FILE_PATH:-"replacements.sed"}")
   if [[ "$originalPath" != "$replacedPath" ]]; then
     >&2 echo "copying to $TARGET_ROOT$replacedPath"
-    cp -pR "$fullPath" "$TARGET_ROOT$replacedPath"
+    cp -R "$fullPath" "$TARGET_ROOT$replacedPath"
   fi
 }
 


### PR DESCRIPTION
Dont preserve timestamps of original file when copying. So that the timestamps in the target folder correspond to the actual appearance on the ftp server, not the creation of the file before it was uploaded to ftp.