### PR TITLE
timestamps on copy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,4 +2,4 @@
 
 ## 2023-03-06
 
-Set created/modified timestamp to now on copy
+Set created/accessed timestamp to now on copy, preserve modified timestamp.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README - copy on write
 
-Docker image to maintain a duplicated directory structure. Works based on filesystem events. Copies a file/directory from a tracked source directory when it is created or moved to the source directory. Timestamps of the original file will not be preserved. Works based on regex substitution. See [replacements](localdev/replacements.sed) for an example mapping.
+Docker image to maintain a duplicated directory structure. Works based on filesystem events. Copies a file/directory from a tracked source directory when it is created or moved to the source directory. Modification time of the original file will be preserved other timestamps will be set to now during the copy. Works based on regex substitution. See [replacements](localdev/replacements.sed) for an example mapping.
 
 On startup existing files/directories in SOURCE_ROOT are mapped and copied to target if mapped.
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -31,7 +31,7 @@ function copyIfMapped {
     # cp will create all new timestamps for the new file
     cp -R "$fullPath" "$TARGET_ROOT$replacedPath"
     # we want to preserve the mtime from the old file, copy the timestamp from the oldfile
-    touch -r "$fullPath" "$TARGET_ROOT$replacedPath" # copies the access & modify time from the oldfile, sets the changetime to now
+    touch -m -r "$fullPath" "$TARGET_ROOT$replacedPath" # take the modify time from the oldfile
   fi
 }
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -28,7 +28,10 @@ function copyIfMapped {
   replacedPath=$(echo "$originalPath" | sed -r -f "${SCRIPT_FILE_PATH:-"replacements.sed"}")
   if [[ "$originalPath" != "$replacedPath" ]]; then
     >&2 echo "copying to $TARGET_ROOT$replacedPath"
+    # cp will create all new timestamps for the new file
     cp -R "$fullPath" "$TARGET_ROOT$replacedPath"
+    # we want to preserve the mtime from the old file, copy the timestamp from the oldfile
+    touch -r "$fullPath" "$TARGET_ROOT$replacedPath" # copies the access & modify time from the oldfile, sets the changetime to now
   fi
 }
 

--- a/localdev/test.sh
+++ b/localdev/test.sh
@@ -46,6 +46,8 @@ cd my_dir
 mv floder folder
 echo "content in sub folder" > subFolder/file.txt
 echo "Hello ContentA" > contentA.txt
+
+contentAMTime=$(stat -f '%m' contentA.txt)
 echo "Some unimportant Content. " > "spacey contentWith $%strange.txt"
 echo "Some unimportant Content. more unimportant content" > "spacey contentWith $%strange.txt"
 cd ../"spacey dir"
@@ -100,6 +102,14 @@ fileShouldExistWithContent() {
 }
 
 fileShouldExistWithContent "other_dir/contentA.txt" "Hello ContentA"
+
+actMTime=$(stat -f '%m' other_dir/contentA.txt)
+
+if [ "$contentAMTime" != "$actMTime" ]; then
+  echo "ContentA should have mTime $contentAMTime but had $actMTime"
+  success="false"
+fi
+
 fileShouldExistWithContent "other_dir/folder/stuff.txt" "content in folder with typo"
 fileShouldExistWithContent "other_dir/spacey contentWith $%strange.txt" "Some unimportant Content. more unimportant content"
 fileShouldExistWithContent "other_dir/subFolder/file.txt" "content in sub folder"


### PR DESCRIPTION
Preserve modified timestamp from original file.
Change other timestamps because the appearance in the target folder will be the relevant timestamp for the importers