### PR TITLE
simplify find command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes for copy-on-write
 
+## 2023-03-13 / 1.0.1
+
+Fixes
+-----
+
+* remove unnecessary call to `bash` in `find --exec`
+
+
 ## 2023-03-06 / 1.0.0
 
 Set created/accessed timestamp to now on copy, preserve modified timestamp.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Tests can be run by executing [test.sh](localdev/test.sh). This requires docker 
 
 ## Development
 
-To test changes, tell compose to rebuild the image before startup: `docker compose up --build`
+To test changes, tell compose to rebuild the image before startup: `docker compose up --build --force-recreate`
 
 ## Limitations
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -24,7 +24,6 @@ function copyIfMapped {
     fullPath="$fullPath/"
   fi
   originalPath=${fullPath#"$SOURCE_ROOT"}
-
   replacedPath=$(echo "$originalPath" | sed -r -f "${SCRIPT_FILE_PATH:-"replacements.sed"}")
   if [[ "$originalPath" != "$replacedPath" ]]; then
     >&2 echo "copying $fullPath to $TARGET_ROOT$replacedPath"
@@ -37,9 +36,13 @@ function copyIfMapped {
 
 export -f copyIfMapped
 
->&2 echo "Watching for files in $SOURCE_ROOT"
+>&2 echo "Searching for mapped files and directories in $SOURCE_ROOT"
+>&2 echo "Checking `find $SOURCE_ROOT | wc -l` items..."
 
-find "$SOURCE_ROOT" -exec bash -c 'copyIfMapped "$1"' bash {} \;
+find "$SOURCE_ROOT" -exec bash -c 'copyIfMapped "{}"' \;
+
+>&2 echo "Watching for updates in $SOURCE_ROOT"
+
 
 #do NOT include the "open" event, copy command will trigger a open event -> resulting in an endless loop
 inotifywait -mr "$SOURCE_ROOT" -e moved_to -e create -e modify --format '%w%f' |


### PR DESCRIPTION
we've been trying to find the reason why it takes 5 minutes to sync 6 files.
turned out that find can only process ~170 files per second (probably because of the bash -c subshell required to run copyIfMapped)

added a log of number of files that will be processed