### PR TITLE
only process files, ignore directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ To test changes, tell compose to rebuild the image before startup: `docker compo
 
 ## Limitations
 
-- when a folder in the source directories is renamed a folder with the corresponding name will be created in target. However, the old folder in target will still exist.
+- when a folder in the source directories is renamed a folder with the mapped name will not be created in target immediately.
+
+  * On restart, the new folder and existing files will be copied.
+  * Howevers, the old folder in target will still exist (not get removed/renamed)
 
 - test.sh depend on output of `stat` command which is filesystem specific (tested on macos with `apfs`)
 

--- a/localdev/replacements.sed
+++ b/localdev/replacements.sed
@@ -24,6 +24,9 @@ s#nested/second/#second/#g
 # folder that will be present on startup already
 s#^existBeforeStart/#mappedDuringStart/#g
 
+# ignore `.dot` files, map only mp3/json, create subdirectories
+s#^on_demand_(\w+)\/([^\.](.+\.(mp3|json)))#ondemand/\1/\2#g
+
 # ATTENTION, replacements are chained:
 # files put into /one will end up in /three
 s#^one/(.*)#two/\1#g

--- a/localdev/replacements.sed
+++ b/localdev/replacements.sed
@@ -1,12 +1,30 @@
-s#.*/(.*)\.(mp3)#music/\1\.\2#g
+# example for mapping with regex groups
+s#songs/artist_(.*)/(.*\.(mp3))#music/\1/\2#g
+
 s#^my_dir/#other_dir/#g
+# leaving out the splash works too
+# ATTENTION: watch out for unwanted chained mappings (see below)
 s#^no_slash_mapping#some_dir#g
+
+s#^empty_dir(.*)#mapped_dir/\1#g
+
+# source / target contains space
 s#^spacey dir/#not_so_spacey_target/#g
 s#^not_so_spacey/#spacey target/#g
-s#^my_other_dir/#also_another_dir/#g
+
+# special characters
 s#^stran"F%lder/#normalFolder/#g
 s#^someNormalFolder/#st"F%lder/#g
+s#^notStrangeFolder/#stranger$Folder/#g
+
+# nested directories
 s#nested/first/#first/#g
 s#nested/second/#second/#g
-s#^notStrangeFolder/#stranger$Folder/#g
+
+# folder that will be present on startup already
 s#^existBeforeStart/#mappedDuringStart/#g
+
+# ATTENTION, replacements are chained:
+# files put into /one will end up in /three
+s#^one/(.*)#two/\1#g
+s#^two/(.*)#three/\1#g

--- a/localdev/test.sh
+++ b/localdev/test.sh
@@ -63,6 +63,12 @@ mkdir unmappedMusicFolder
 echo "content in folder with typo" > my_dir/floder/stuff.txt
 sleep 1
 
+mkdir "on_demand_argovia"
+touch "on_demand_argovia/.in.C055AA93-BC24.json"
+touch "on_demand_argovia/C055AA93-BC24.mp3"
+touch "on_demand_argovia/C055AA93-BC24.json"
+touch "on_demand_argovia/C055AA93-BC24.txt"
+
 cd my_dir
 mv floder folder
 echo "content in sub folder" > subFolder/file.txt
@@ -116,6 +122,13 @@ dirShouldExist "music"
 fileShouldExist() {
   if [ ! -f "$1" ]; then
     echo "File $1 should exist but didnt"
+    success="false"
+  fi
+}
+
+fileShouldNotExist() {
+  if [ -f "$1" ]; then
+    echo "File $1 should not exist but did"
     success="false"
   fi
 }
@@ -177,6 +190,14 @@ fi
 
 fileShouldExistWithContent "mappedDuringStart/some spacey starter.txt" "some other content"
 fileShouldExistWithContent "mappedDuringStart/some strange %'12&( starter.txt" "a"
+
+# interim directories have been created
+dirShouldExist "ondemand/argovia"
+fileShouldExist "ondemand/argovia/C055AA93-BC24.mp3"
+fileShouldExist "ondemand/argovia/C055AA93-BC24.json"
+# dot file and txt not mapped
+fileShouldNotExist "ondemand/argovia/.in.C055AA93-BC24.json"
+fileShouldNotExist "ondemand/argovia/C055AA93-BC24.txt"
 
 cd ../..
 


### PR DESCRIPTION
this means: empty directories won't be copied.

however, it is now possible to only process files that would be mapped (eg certain extensions) that reside in subdirectories without the need to create these subdirectories before running the script, or having this script copy the complete subdirectory (including files what would not be mapped)