### PR TITLE
skip existing files on startup, don't update them

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changes for copy-on-write
 
+## Unreleased
+
+### Breaking
+
+* Do not preserve modified timestamp on copy as on most unix filesystems the
+  creation time of a file is not accessible so the mtime is the ts our file
+  got processed by copy-on-write
+
+### Fixes
+
+* Do not re-process (update) existing files on restart
+
 ## 2023-04-05 / 1.1.0
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # README - copy on write
 
-Docker image to maintain a duplicated directory structure. Works based on filesystem events. Copies a file/directory from a tracked source directory when it is created or moved to the source directory. Modification time of the original file will be preserved other timestamps will be set to now during the copy. Works based on regex substitution. See [replacements](localdev/replacements.sed) for an example mapping.
+Docker image to maintain a duplicated directory structure. Works based on filesystem events. Copies a file/directory from a tracked source directory when it is created or moved to the source directory.
+All timestamps will be set to now during the copy, no timestamps are preserved. This way we make sure we have monotonous rising timestamps for incoming files. 
 
-On startup existing files/directories in SOURCE_ROOT are mapped and copied to target if mapped.
+Works based on regex substitution. See [replacements](localdev/replacements.sed) for an example mapping.
+
+On startup existing files in SOURCE_ROOT are copied to target if mapped.
 
 See [localdev/docker-compose.yml](localdev/docker-compose.yml) for an example configuration.
 
@@ -16,11 +19,11 @@ To test changes, tell compose to rebuild the image before startup: `docker compo
 
 ## Limitations
 
+- existing files (matching name) won't get updated (file content/metadata is not compared)
+
 - when a folder in the source directories is renamed a folder with the mapped name will not be created in target immediately.
 
   * On restart, the new folder and existing files will be copied.
   * Howevers, the old folder in target will still exist (not get removed/renamed)
-
-- test.sh depend on output of `stat` command which is filesystem specific (tested on macos with `apfs`)
 
 - on linux test.sh needs to be run as root user (or docker/docker-compose configured to run with the current user)

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -27,7 +27,14 @@ function copyIfMapped {
 
   originalPath=${fullPath#"$SOURCE_ROOT"}
   replacedPath=$(echo "$originalPath" | sed -r -f "${SCRIPT_FILE_PATH:-"replacements.sed"}")
+
+  if [ -f "$TARGET_ROOT$replacedPath" ]; then
+    # do not overwrite existing files, just skip them
+    return
+  fi
+
   if [[ "$originalPath" != "$replacedPath" ]]; then
+
     >&2 echo "copying $fullPath to $TARGET_ROOT$replacedPath"
 
     directory="$(dirname "$TARGET_ROOT$replacedPath")"
@@ -38,8 +45,6 @@ function copyIfMapped {
 
     # cp will create all new timestamps for the new file
     cp "$fullPath" "$TARGET_ROOT$replacedPath"
-    # we want to preserve the mtime from the old file, copy the timestamp from the oldfile
-    touch -m -r "$fullPath" "$TARGET_ROOT$replacedPath" # take the modify time from the oldfile
   fi
 }
 

--- a/localdev/replacements.sed
+++ b/localdev/replacements.sed
@@ -2,7 +2,7 @@
 s#songs/artist_(.*)/(.*\.(mp3))#music/\1/\2#g
 
 s#^my_dir/#other_dir/#g
-# leaving out the splash works too
+# leaving out the slash works too
 # ATTENTION: watch out for unwanted chained mappings (see below)
 s#^no_slash_mapping#some_dir#g
 


### PR DESCRIPTION
also to not rely on file-birth-time which is not available on many unix filesystems.
instead reset modification timestamp for incoming files too.