### PR TITLE
write *.part files first and rename when file is complete 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes for copy-on-write
 
+## Unrelased
+
+### Breaking
+
+* Copy to `*.part` files and rename file when complete. This allows watchers to be sure
+  a file is complete when the `create` event is fired.
+
 ## 2023-04-18 / 1.2.0
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ To test changes, tell compose to rebuild the image before startup: `docker compo
 - when a folder in the source directories is renamed a folder with the mapped name will not be created in target immediately.
 
   * On restart, the new folder and existing files will be copied.
-  * Howevers, the old folder in target will still exist (not get removed/renamed)
+  * However, the old folder in target will still exist (not get removed/renamed)
 
 - on linux test.sh needs to be run as root user (or docker/docker-compose configured to run with the current user)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Works based on regex substitution. See [replacements](localdev/replacements.sed)
 
 On startup existing files in SOURCE_ROOT are copied to target if mapped.
 
+To make sure a file that ends up in the target directory is complete, a `.part` extension is added and
+the file is renamed when copy has finished.
+Make sure to exclude `*.part` files when using watchers to process files in the target directory.
+
 See [localdev/docker-compose.yml](localdev/docker-compose.yml) for an example configuration.
 
 ## Tests

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.16.4
-#do NOT upgrad alpine version, alpine 3.17.0, the version needed for inotify-tools isnt available
+FROM alpine:3.16.5
+#do NOT upgrade alpine version, alpine 3.17.0, the version needed for inotify-tools isn't available
 RUN apk add --no-cache bash && apk add --no-cache inotify-tools
 
 COPY ./docker-entrypoint.sh /

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -44,7 +44,11 @@ function copyIfMapped {
     fi
 
     # cp will create all new timestamps for the new file
-    cp "$fullPath" "$TARGET_ROOT$replacedPath"
+    cp "$fullPath" "$TARGET_ROOT$replacedPath.part"
+    # copy to a *.part file and rename when complete to make sure
+    # watchers will process a complete file (create event is fired before file is complete)
+    mv "$TARGET_ROOT$replacedPath.part" "$TARGET_ROOT$replacedPath"
+
   fi
 }
 

--- a/localdev/test.sh
+++ b/localdev/test.sh
@@ -44,7 +44,7 @@ cp -a volumes/src/update_test/file.txt volumes/target/update_test_target/
 echo "some other content" > "volumes/src/existBeforeStart/some spacey starter.txt"
 echo "a" > "volumes/src/existBeforeStart/some strange %'12&( starter.txt"
 
-sleep 1
+sleep 2
 # update the update_test file (simulate an update of a previously copied file and a restart)
 echo "updated content" > volumes/src/update_test/file.txt
 


### PR DESCRIPTION
This allows watchers to be sure a file is complete when the `create` event is fired.